### PR TITLE
FIX: MOVE MARKDOWN PATCH TO HIGHLIGHT TEMPLATE

### DIFF
--- a/hallelujah/templates/_base.html
+++ b/hallelujah/templates/_base.html
@@ -106,9 +106,6 @@
             <script type="text/javascript" src="{{ url_for('static', filename='js/style.js', _external=True) }}"></script>
             {{ moment.include_moment() }}
         {% endblock scripts %}
-            <script type="text/javascript">
-                loadcssfile("{{ url_for('static', filename='css/markdown_patch.css', _external=True) }}");
-            </script>
     </body>
 </html>
 

--- a/hallelujah/templates/_highlight.html
+++ b/hallelujah/templates/_highlight.html
@@ -13,6 +13,7 @@
     <script type="text/javascript">
         hljs.highlightAll();
         hljs.initLineNumbersOnLoad();
+        loadcssfile("{{ url_for('static', filename='css/markdown_patch.css', _external=True) }}");
     </script>
 {% endblock scripts %}
 


### PR DESCRIPTION
move code markdown patch to highlight template, remove redundant css from other pages.