### PR TITLE
STYLE: MAKE CODE SECTION BACKGROUND DARK

### DIFF
--- a/hallelujah/static/css/markdown_patch.css
+++ b/hallelujah/static/css/markdown_patch.css
@@ -9,11 +9,12 @@
 }
 .markdown-body table tr:nth-child(2n) {
     background-color: transparent;
-    opacity: 0.7;
+    opacity: 1.0;
 }
 .markdown-body pre {
     margin-top, margin-bottom: 5px;
     padding: 0;
+    background-color: #cccccc;
 }
 .markdown-body code.hljs {
     white-space: pre-wrap;
@@ -48,8 +49,8 @@
     user-select: none;
     text-align: right;
     vertical-align: top;
-    color: #ccc;
-    border-right: 1px solid #ccc;
+    color: #999999;
+    border-right: 1px solid #999999;
     width: 1rem;
     min-width: 1rem;
 }


### PR DESCRIPTION
make markdown pre code block background dark, eliminates odd/even opacity.